### PR TITLE
Don't link Homebrew libzstd into macOS binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,13 +50,8 @@ jobs:
     - name: get llvm-project
       # https://github.com/llvm/llvm-project/releases/download/llvmorg-22.1.8/llvm-project-22.1.8.src.tar.xz
       run: |
-        curl -L https://github.com/llvm/llvm-project/releases/download/llvmorg-${{ env.TAG }}/${{ env.LLVM_VERSION }}.tar.xz \
-        | \
-        tar -xJ \
-          --exclude=${{ env.LLVM_VERSION }}/clang/test/Driver/Inputs/* \
-          --exclude=${{ env.LLVM_VERSION }}/libcxx/test/std/input.output/filesystems/Inputs/static_test_env/* \
-          --exclude=${{ env.LLVM_VERSION }}/libclc/amdgcn-mesa3d
-
+        curl -L -o ${{ env.LLVM_VERSION }}.tar.xz https://github.com/llvm/llvm-project/releases/download/llvmorg-${{ env.TAG }}/${{ env.LLVM_VERSION }}.tar.xz
+        tar -xJf ${{ env.LLVM_VERSION }}.tar.xz --exclude lldb/test || tar -xJf ${{ env.LLVM_VERSION }}.tar.xz
     - name: cmake
       run: |
         cd ${{ env.LLVM_VERSION }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,89 +7,74 @@ on:
 
 env:
   DIST_DIR: dist
-    # The project's folder on Arduino's download server for uploading builds
+  # The project's folder on Arduino's download server for uploading builds
   AWS_PLUGIN_TARGET: /tools/
   AWS_REGION: "us-east-1"
+  TAG: ${{ github.ref_name }}
+  LLVM_VERSION: llvm-project-${{ github.ref_name }}.src
+  COMMON_CMAKE_ARGS: '-DBUILD_SHARED_LIBS=OFF -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra"'
 
 jobs:
-
-  get-version:
-    runs-on: ubuntu-latest
-    outputs:
-      tag: ${{ steps.get-tag.outputs.TAG}}
-      llvm-version: ${{ steps.get-version.outputs.LLVM_VERSION}}
-    steps:
-      - id: get-tag
-        run: echo ::set-output name=TAG::${GITHUB_REF/refs\/tags\//}
-      - id: get-version
-        run: echo ::set-output name=LLVM_VERSION::llvm-project-${GITHUB_REF/refs\/tags\//}.src
-
   build-win-mac:
-    needs: get-version
     name: build (${{ matrix.config.name }}, ${{ matrix.config.arch }})
     runs-on:
-      ${{ matrix.config.os }}
+      ${{ matrix.config.runner }}
     strategy:
       matrix:
         config:
           - name: macOS
-            os: macos-latest
+            arch: 64bit
+            runner: macos-latest
             os-cmake-args: '-DCMAKE_OSX_DEPLOYMENT_TARGET=10.15 -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang'
             build-args: '-j$(sysctl -n hw.ncpu)'
             bindir: '/build/bin'
+          - name: Windows
             arch: 64bit
-          - name: Windows
-            os: windows-latest
-            os-cmake-args: '-DCMAKE_CXX_FLAGS="/MP /std:c++14" -DLLVM_USE_CRT_MINSIZEREL="MT"'
-            build-args: '--config MinSizeRel'
-            bindir: '/build/MinSizeRel/bin'
-            extra-tar-args: '--exclude=${{ needs.get-version.outputs.llvm-version }}/clang/test/Driver/Inputs/* --exclude=${{ needs.get-version.outputs.llvm-version }}/libcxx/test/std/input.output/filesystems/Inputs/static_test_env/* --exclude=${{ needs.get-version.outputs.llvm-version }}/libclc/amdgcn-mesa3d'
-            arch: 32bit
-            extension: .exe
-          - name: Windows
-            os: windows-latest
+            runner: windows-latest
             os-cmake-args: '-Thost=x64 -DCMAKE_CXX_FLAGS="/MP /std:c++14" -DLLVM_USE_CRT_MINSIZEREL="MT"'
             build-args: '--config MinSizeRel'
             bindir: '/build/MinSizeRel/bin'
-            arch: 64bit
-            extra-tar-args: '--exclude=${{ needs.get-version.outputs.llvm-version }}/clang/test/Driver/Inputs/* --exclude=${{ needs.get-version.outputs.llvm-version }}/libcxx/test/std/input.output/filesystems/Inputs/static_test_env/* --exclude=${{ needs.get-version.outputs.llvm-version }}/libclc/amdgcn-mesa3d'
             extension: .exe
-    env:
-      COMMON_CMAKE_ARGS: '-DBUILD_SHARED_LIBS=OFF -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra"'
     defaults:
       run:
         shell: bash
 
     steps:
     - name: get llvm-project
-      run: curl -L https://github.com/llvm/llvm-project/releases/download/llvmorg-${{ needs.get-version.outputs.tag }}/${{ needs.get-version.outputs.llvm-version }}.tar.xz | tar -xJ ${{ matrix.config.extra-tar-args }}
+      # https://github.com/llvm/llvm-project/releases/download/llvmorg-22.1.8/llvm-project-22.1.8.src.tar.xz
+      run: |
+        curl -L https://github.com/llvm/llvm-project/releases/download/llvmorg-${{ env.TAG }}/${{ env.LLVM_VERSION }}.tar.xz \
+        | \
+        tar -xJ \
+          --exclude=${{ env.LLVM_VERSION }}/clang/test/Driver/Inputs/* \
+          --exclude=${{ env.LLVM_VERSION }}/libcxx/test/std/input.output/filesystems/Inputs/static_test_env/* \
+          --exclude=${{ env.LLVM_VERSION }}/libclc/amdgcn-mesa3d
 
     - name: cmake
       run: |
-        cd ${{ needs.get-version.outputs.llvm-version }}
+        cd ${{ env.LLVM_VERSION }}
         mkdir build
         cd build
         cmake ../llvm ${{ env.COMMON_CMAKE_ARGS }} ${{ matrix.config.os-cmake-args }}
 
     - name: build
-      run: cmake --build ${{ needs.get-version.outputs.llvm-version }}/build ${{ matrix.config.build-args }} --target clang-format clangd
+      run: cmake --build ${{ env.LLVM_VERSION }}/build ${{ matrix.config.build-args }} --target clang-format clangd
 
     - name: print macos dependencies
       run:  |
-        otool -L ${{ needs.get-version.outputs.llvm-version }}${{ matrix.config.bindir }}/clangd
-        otool -L ${{ needs.get-version.outputs.llvm-version }}${{ matrix.config.bindir }}/clang-format
-      if: matrix.config.os == 'macos-latest'
+        otool -L ${{ env.LLVM_VERSION }}${{ matrix.config.bindir }}/clangd
+        otool -L ${{ env.LLVM_VERSION }}${{ matrix.config.bindir }}/clang-format
+      if: matrix.config.runner == 'macos-latest'
 
     - name: upload artifacts
       uses: actions/upload-artifact@v7
       with:
         name: clang_${{ matrix.config.name }}_${{ matrix.config.arch }}
         path: |
-          ${{ needs.get-version.outputs.llvm-version }}${{ matrix.config.bindir }}/clangd${{ matrix.config.extension }}
-          ${{ needs.get-version.outputs.llvm-version }}${{ matrix.config.bindir }}/clang-format${{ matrix.config.extension }}
+          ${{ env.LLVM_VERSION }}${{ matrix.config.bindir }}/clangd${{ matrix.config.extension }}
+          ${{ env.LLVM_VERSION }}${{ matrix.config.bindir }}/clang-format${{ matrix.config.extension }}
 
   build-linux:
-    needs: get-version
     name: build (${{ matrix.config.name }}, ${{ matrix.config.arch }})
     runs-on:
       ubuntu-latest
@@ -121,14 +106,14 @@ jobs:
       run: echo "COMMON_CMAKE_ARGS=-DBUILD_SHARED_LIBS=OFF -DLLVM_ENABLE_PROJECTS=\"clang;clang-tools-extra\" -DCMAKE_CXX_FLAGS=\"-s -static-libstdc++ -static-libgcc\" -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_SYSTEM_NAME=\"Linux\"" >> $GITHUB_ENV
 
     - name: get llvm-project
-      run: curl -L https://github.com/llvm/llvm-project/releases/download/llvmorg-${{ needs.get-version.outputs.tag }}/${{ needs.get-version.outputs.llvm-version }}.tar.xz | tar -xJ
+      run: curl -L https://github.com/llvm/llvm-project/releases/download/llvmorg-${{ env.TAG }}/${{ env.LLVM_VERSION }}.tar.xz | tar -xJ
 
     - name: install Ninja
       run: apt update && apt install ninja-build
 
     - name: build llvm-tblgen clang-tblgen with the host toolchain
       run: |
-        cd ${{ needs.get-version.outputs.llvm-version }}
+        cd ${{ env.LLVM_VERSION }}
         mkdir -p build
         cd build
         cmake -G Ninja ../llvm  ${{ env.COMMON_CMAKE_ARGS }} -DCMAKE_CXX_COMPILER=x86_64-ubuntu16.04-linux-gnu-g++ -DCMAKE_C_COMPILER=x86_64-ubuntu16.04-linux-gnu-gcc
@@ -140,7 +125,7 @@ jobs:
 
     - name: build clangd and clang-format
       run: |
-        cd ${{ needs.get-version.outputs.llvm-version }}
+        cd ${{ env.LLVM_VERSION }}
         mkdir -p build
         cd build
         cmake -G Ninja ../llvm ${{ env.COMMON_CMAKE_ARGS }}  ${{ matrix.config.os-cmake-args }}
@@ -151,13 +136,13 @@ jobs:
       with:
         name: clang_${{ matrix.config.name }}_${{ matrix.config.arch }}
         path: |
-          ${{ needs.get-version.outputs.llvm-version }}/build/bin/clangd*
-          ${{ needs.get-version.outputs.llvm-version }}/build/bin/clang-format*
+          ${{ env.LLVM_VERSION }}/build/bin/clangd*
+          ${{ env.LLVM_VERSION }}/build/bin/clang-format*
 
   create-release:
     runs-on: ubuntu-latest
     environment: production
-    needs: [build-linux, build-win-mac, get-version]
+    needs: [build-linux, build-win-mac]
     permissions:
       contents: write
       id-token: write # This is required for requesting the JWT
@@ -173,8 +158,8 @@ jobs:
           for folder in "${target_folders[@]}"
           do
             chmod -v +x clang_$folder/*
-            CLANGD=clangd_${{ needs.get-version.outputs.tag }}_${folder}.tar.bz2
-            CLANGFORMAT=clang-format_${{ needs.get-version.outputs.tag }}_${folder}.tar.bz2
+            CLANGD=clangd_${{ env.TAG }}_${folder}.tar.bz2
+            CLANGFORMAT=clang-format_${{ env.TAG }}_${folder}.tar.bz2
             tar -cvjf $CLANGD clang_$folder/clangd*
             tar -cvjf $CLANGFORMAT clang_$folder/clang-format*
           done
@@ -189,12 +174,12 @@ jobs:
           # (all the files we need are in the release folder root)
           artifacts: ${{ env.DIST_DIR }}/*
 
-      - name: configure aws credentials
-        uses: aws-actions/configure-aws-credentials@v5
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          role-session-name: "github_${{ env.PROJECT_NAME }}"
-          aws-region: ${{ env.AWS_REGION }}
-
-      - name: Upload release files on Arduino downloads servers
-        run: aws s3 sync ${{ env.DIST_DIR }} s3://${{ secrets.DOWNLOADS_BUCKET }}${{ env.AWS_PLUGIN_TARGET }}
+#      - name: configure aws credentials
+#        uses: aws-actions/configure-aws-credentials@v5
+#        with:
+#          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+#          role-session-name: "github_${{ env.PROJECT_NAME }}"
+#          aws-region: ${{ env.AWS_REGION }}
+#
+#      - name: Upload release files on Arduino downloads servers
+#        run: aws s3 sync ${{ env.DIST_DIR }} s3://${{ secrets.DOWNLOADS_BUCKET }}${{ env.AWS_PLUGIN_TARGET }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,46 +16,40 @@ env:
 
 jobs:
   build:
-    name: build (${{ matrix.config.name }}, ${{ matrix.config.arch }})
+    name: Build (${{ matrix.config.name }})
     runs-on:
       ${{ matrix.config.runner }}
     strategy:
       matrix:
         config:
-          - name: macOS
-            arch: 64bit
+          - name: macOS_64bit
             runner: macos-15-intel
             os-cmake-args: '-DCMAKE_OSX_DEPLOYMENT_TARGET=10.15 -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang'
             build-args: '-j$(sysctl -n hw.ncpu)'
             bindir: '/build/bin'
-          - name: macOS
-            arch: ARM64
+          - name: macOS_ARM64
             runner: macos-15
             os-cmake-args: '-DCMAKE_OSX_DEPLOYMENT_TARGET=10.15 -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang'
             build-args: '-j$(sysctl -n hw.ncpu)'
             bindir: '/build/bin'
-          - name: Windows
-            arch: 64bit
+          - name: Windows_64bit
             runner: windows-latest
             os-cmake-args: '-Thost=x64 -DCMAKE_CXX_FLAGS="/MP /std:c++14" -DLLVM_USE_CRT_MINSIZEREL="MT"'
             build-args: '--config MinSizeRel'
             bindir: '/build/MinSizeRel/bin'
             extension: .exe
-          - name: Windows
-            arch: ARM64
+          - name: Windows_ARM64
             runner: windows-11-arm
             os-cmake-args: '-DCMAKE_CXX_FLAGS="/MP /std:c++14" -DLLVM_USE_CRT_MINSIZEREL="MT"'
             build-args: '--config MinSizeRel'
             bindir: '/build/MinSizeRel/bin'
             extension: .exe
-          - name: Linux
-            arch: 64bit
+          - name: Linux_64bit
             runner: ubuntu-22.04
             os-cmake-args: ''
             build-args: '-j$(nproc)'
             bindir: '/build/bin'
-          - name: Linux
-            arch: ARM64
+          - name: Linux_ARM64
             runner: ubuntu-22.04-arm
             os-cmake-args: ''
             build-args: '-j$(nproc)'
@@ -65,31 +59,30 @@ jobs:
         shell: bash
 
     steps:
-    - name: get llvm-project
+    - name: Get llvm-project
       # https://github.com/llvm/llvm-project/releases/download/llvmorg-22.1.8/llvm-project-22.1.8.src.tar.xz
       run: |
         curl -L -o ${{ env.LLVM_VERSION }}.tar.xz https://github.com/llvm/llvm-project/releases/download/llvmorg-${{ env.TAG }}/${{ env.LLVM_VERSION }}.tar.xz
         tar -xJf ${{ env.LLVM_VERSION }}.tar.xz --exclude lldb/test || tar -xJf ${{ env.LLVM_VERSION }}.tar.xz
-    - name: cmake
+      
+    - name: Build
       run: |
         cd ${{ env.LLVM_VERSION }}
         mkdir build
         cd build
         cmake ../llvm ${{ env.COMMON_CMAKE_ARGS }} ${{ matrix.config.os-cmake-args }}
+        cmake --build ${{ env.LLVM_VERSION }}/build ${{ matrix.config.build-args }} --target clang-format clangd
 
-    - name: build
-      run: cmake --build ${{ env.LLVM_VERSION }}/build ${{ matrix.config.build-args }} --target clang-format clangd
-
-    - name: print macos dependencies
+    - name: Print macOS dependencies
+      if: contains(matrix.config.runner, 'macos')
       run:  |
         otool -L ${{ env.LLVM_VERSION }}${{ matrix.config.bindir }}/clangd
         otool -L ${{ env.LLVM_VERSION }}${{ matrix.config.bindir }}/clang-format
-      if: matrix.config.runner == 'macos-latest'
 
-    - name: upload artifacts
+    - name: Upload artifacts
       uses: actions/upload-artifact@v7
       with:
-        name: clang_${{ matrix.config.name }}_${{ matrix.config.arch }}
+        name: clang_${{ matrix.config.name }}
         path: |
           ${{ env.LLVM_VERSION }}${{ matrix.config.bindir }}/clangd${{ matrix.config.extension }}
           ${{ env.LLVM_VERSION }}${{ matrix.config.bindir }}/clang-format${{ matrix.config.extension }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ env:
   COMMON_CMAKE_ARGS: '-DBUILD_SHARED_LIBS=OFF -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra"'
 
 jobs:
-  build-win-mac:
+  build:
     name: build (${{ matrix.config.name }}, ${{ matrix.config.arch }})
     runs-on:
       ${{ matrix.config.runner }}
@@ -24,7 +24,13 @@ jobs:
         config:
           - name: macOS
             arch: 64bit
-            runner: macos-latest
+            runner: macos-15-intel
+            os-cmake-args: '-DCMAKE_OSX_DEPLOYMENT_TARGET=10.15 -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang'
+            build-args: '-j$(sysctl -n hw.ncpu)'
+            bindir: '/build/bin'
+          - name: macOS
+            arch: ARM64
+            runner: macos-15
             os-cmake-args: '-DCMAKE_OSX_DEPLOYMENT_TARGET=10.15 -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang'
             build-args: '-j$(sysctl -n hw.ncpu)'
             bindir: '/build/bin'
@@ -42,6 +48,18 @@ jobs:
             build-args: '--config MinSizeRel'
             bindir: '/build/MinSizeRel/bin'
             extension: .exe
+          - name: Linux
+            arch: 64bit
+            runner: ubuntu-22.04
+            os-cmake-args: ''
+            build-args: '-j$(nproc)'
+            bindir: '/build/bin'
+          - name: Linux
+            arch: ARM64
+            runner: ubuntu-22.04-arm
+            os-cmake-args: ''
+            build-args: '-j$(nproc)'
+            bindir: '/build/bin'
     defaults:
       run:
         shell: bash
@@ -76,75 +94,10 @@ jobs:
           ${{ env.LLVM_VERSION }}${{ matrix.config.bindir }}/clangd${{ matrix.config.extension }}
           ${{ env.LLVM_VERSION }}${{ matrix.config.bindir }}/clang-format${{ matrix.config.extension }}
 
-  build-linux:
-    name: build (${{ matrix.config.name }}, ${{ matrix.config.arch }})
-    runs-on:
-      ubuntu-latest
-    # apparently env vars cannot be defined here with container (https://github.community/t/how-to-use-env-with-container-image/17252)
-    strategy:
-      matrix:
-        config:
-          - name: Linux
-            arch: 64bit
-            os-cmake-args: '-DCMAKE_CXX_COMPILER=x86_64-ubuntu16.04-linux-gnu-g++ -DCMAKE_C_COMPILER=x86_64-ubuntu16.04-linux-gnu-gcc'
-          - name: Linux
-            arch: 32bit
-            os-cmake-args: '-DCMAKE_CXX_COMPILER=i686-ubuntu16.04-linux-gnu-g++ -DCMAKE_C_COMPILER=i686-ubuntu16.04-linux-gnu-gcc'
-          - name: Linux
-            arch: ARMv6
-            os-cmake-args: '-DCMAKE_CXX_COMPILER=arm-linux-gnueabihf-g++ -DCMAKE_C_COMPILER=arm-linux-gnueabihf-gcc -DCMAKE_CROSSCOMPILING=True -DLLVM_DEFAULT_TARGET_TRIPLE=arm-linux-gnueabihf -DLLVM_TARGET_ARCH=ARM -DLLVM_TARGETS_TO_BUILD=ARM -DLLVM_TABLEGEN=/tmp/llvm-tblgen -DCLANG_TABLEGEN=/tmp/clang-tblgen'
-          - name: Linux
-            arch: ARM64
-            os-cmake-args: '-DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DCMAKE_CROSSCOMPILING=True -DLLVM_TARGET_ARCH=AArch64 -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=AArch64 -DLLVM_TABLEGEN=/tmp/llvm-tblgen -DCLANG_TABLEGEN=/tmp/clang-tblgen'
-
-    container:
-      image: ghcr.io/arduino/crossbuild:latest
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.CLANG_CI_PAT }}
-
-    steps:
-    - name: Set env vars
-      run: echo "COMMON_CMAKE_ARGS=-DBUILD_SHARED_LIBS=OFF -DLLVM_ENABLE_PROJECTS=\"clang;clang-tools-extra\" -DCMAKE_CXX_FLAGS=\"-s -static-libstdc++ -static-libgcc\" -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_SYSTEM_NAME=\"Linux\"" >> $GITHUB_ENV
-
-    - name: get llvm-project
-      run: curl -L https://github.com/llvm/llvm-project/releases/download/llvmorg-${{ env.TAG }}/${{ env.LLVM_VERSION }}.tar.xz | tar -xJ
-
-    - name: install Ninja
-      run: apt update && apt install ninja-build
-
-    - name: build llvm-tblgen clang-tblgen with the host toolchain
-      run: |
-        cd ${{ env.LLVM_VERSION }}
-        mkdir -p build
-        cd build
-        cmake -G Ninja ../llvm  ${{ env.COMMON_CMAKE_ARGS }} -DCMAKE_CXX_COMPILER=x86_64-ubuntu16.04-linux-gnu-g++ -DCMAKE_C_COMPILER=x86_64-ubuntu16.04-linux-gnu-gcc
-        ninja llvm-tblgen clang-tblgen
-        cp -v bin/llvm-tblgen /tmp
-        cp -v bin/clang-tblgen /tmp
-        rm -rf *
-      if: matrix.config.arch == 'ARMv6' || matrix.config.arch == 'ARM64'
-
-    - name: build clangd and clang-format
-      run: |
-        cd ${{ env.LLVM_VERSION }}
-        mkdir -p build
-        cd build
-        cmake -G Ninja ../llvm ${{ env.COMMON_CMAKE_ARGS }}  ${{ matrix.config.os-cmake-args }}
-        ninja clang-format clangd
-
-    - name: upload artifacts
-      uses: actions/upload-artifact@v7
-      with:
-        name: clang_${{ matrix.config.name }}_${{ matrix.config.arch }}
-        path: |
-          ${{ env.LLVM_VERSION }}/build/bin/clangd*
-          ${{ env.LLVM_VERSION }}/build/bin/clang-format*
-
   create-release:
     runs-on: ubuntu-latest
     environment: production
-    needs: [build-linux, build-win-mac]
+    needs: build
     permissions:
       contents: write
       id-token: write # This is required for requesting the JWT
@@ -156,7 +109,7 @@ jobs:
       - name: Prepare artifacts for the release
         run: |
           mkdir ${{ env.DIST_DIR }}
-          declare -a target_folders=("Linux_64bit" "Linux_32bit" "Linux_ARM64" "Linux_ARMv6" "macOS_64bit" "Windows_32bit" "Windows_64bit")
+          declare -a target_folders=("Linux_64bit" "Linux_ARM64" "macOS_64bit" "macOS_ARM64" "Windows_64bit" "Windows_ARM64")
           for folder in "${target_folders[@]}"
           do
             chmod -v +x clang_$folder/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,14 @@ env:
   AWS_PLUGIN_TARGET: /tools/
   AWS_REGION: "us-east-1"
   TAG: ${{ github.ref_name }}
-  LLVM_VERSION: llvm-project-${{ github.ref_name }}.src
-  COMMON_CMAKE_ARGS: '-DBUILD_SHARED_LIBS=OFF -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra"'
+  # LLVM_VERSION is derived from TAG by the "Get llvm-project" step, so that a
+  # build-revision tag (e.g. 22.1.8-1) still resolves to the 22.1.8 LLVM sources.
+  # NOTE: zstd is deliberately disabled. LLVM_ENABLE_ZSTD defaults to ON, which means
+  # "link zstd if CMake finds it" -- on the macOS runners it finds Homebrew's copy and
+  # bakes an absolute /opt/homebrew (or /usr/local/opt) path into the binary, which then
+  # fails to load on any Mac without that exact Homebrew install. Nothing we ship needs
+  # zstd. Do NOT disable zlib the same way: clangd's index uses it.
+  COMMON_CMAKE_ARGS: '-DBUILD_SHARED_LIBS=OFF -DLLVM_ENABLE_ZSTD=OFF -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra"'
 
 jobs:
   build:
@@ -62,22 +68,36 @@ jobs:
     - name: Get llvm-project
       # https://github.com/llvm/llvm-project/releases/download/llvmorg-22.1.8/llvm-project-22.1.8.src.tar.xz
       run: |
-        curl -L -o ${{ env.LLVM_VERSION }}.tar.xz https://github.com/llvm/llvm-project/releases/download/llvmorg-${{ env.TAG }}/${{ env.LLVM_VERSION }}.tar.xz
-        tar -xJf ${{ env.LLVM_VERSION }}.tar.xz --exclude lldb/test || tar -xJf ${{ env.LLVM_VERSION }}.tar.xz
-      
+        # Strip any build-revision suffix: the tag may be 22.1.8-1, but upstream only
+        # publishes llvmorg-22.1.8. Exposed to later steps via GITHUB_ENV.
+        LLVM_TAG="${TAG%%-*}"
+        LLVM_SRC="llvm-project-${LLVM_TAG}.src"
+        echo "LLVM_VERSION=$LLVM_SRC" >> "$GITHUB_ENV"
+        curl -fL -o "$LLVM_SRC.tar.xz" \
+          "https://github.com/llvm/llvm-project/releases/download/llvmorg-${LLVM_TAG}/$LLVM_SRC.tar.xz"
+        tar -xJf "$LLVM_SRC.tar.xz" --exclude lldb/test || tar -xJf "$LLVM_SRC.tar.xz"
+
     - name: Build
       run: |
         cd ${{ env.LLVM_VERSION }}
         mkdir build
         cd build
         cmake ../llvm ${{ env.COMMON_CMAKE_ARGS }} ${{ matrix.config.os-cmake-args }}
-        cmake --build ${{ env.LLVM_VERSION }}/build ${{ matrix.config.build-args }} --target clang-format clangd
+        cmake --build . ${{ matrix.config.build-args }} --target clang-format clangd
 
-    - name: Print macOS dependencies
+    - name: Check macOS dependencies
       if: contains(matrix.config.runner, 'macos')
-      run:  |
-        otool -L ${{ env.LLVM_VERSION }}${{ matrix.config.bindir }}/clangd
-        otool -L ${{ env.LLVM_VERSION }}${{ matrix.config.bindir }}/clang-format
+      run: |
+        status=0
+        for bin in clangd clang-format; do
+          path="${{ env.LLVM_VERSION }}${{ matrix.config.bindir }}/$bin"
+          otool -L "$path"
+          if otool -L "$path" | tail -n +2 | grep -E '/opt/homebrew|/usr/local/opt|/opt/local'; then
+            echo "::error::$bin links a host-specific library path; it will not load on a clean Mac"
+            status=1
+          fi
+        done
+        exit $status
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,13 @@ jobs:
             build-args: '--config MinSizeRel'
             bindir: '/build/MinSizeRel/bin'
             extension: .exe
+          - name: Windows
+            arch: ARM64
+            runner: windows-11-arm
+            os-cmake-args: '-DCMAKE_CXX_FLAGS="/MP /std:c++14" -DLLVM_USE_CRT_MINSIZEREL="MT"'
+            build-args: '--config MinSizeRel'
+            bindir: '/build/MinSizeRel/bin'
+            extension: .exe
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
[Author - Claude Opus 5]

## Problem

The macOS `clangd` and `clang-format` binaries we publish link libzstd by **absolute Homebrew path**, so they fail to load on any Mac without that exact Homebrew install.

Reproduced with `otool -L` on the real published artifacts:

| Artifact | Result |
|---|---|
| `clangd_22.1.8_macOS_ARM64` | `/opt/homebrew/opt/zstd/lib/libzstd.1.dylib` |
| `clangd_22.1.8_macOS_64bit` | `/usr/local/opt/zstd/lib/libzstd.1.dylib` |
| `clangd_15.0.0_macOS_ARM64` | `/opt/homebrew/opt/zstd/lib/libzstd.1.dylib` |
| `clangd_14.0.0_macOS_ARM64` / `_64bit` | clean — `/usr/lib` only |

`LLVM_ENABLE_ZSTD` defaults to `ON`, which in LLVM means *"link zstd if CMake finds it"*, not *"require it"*. The macOS runners have Homebrew, CMake finds it, and the path lands in the Mach-O load commands.

**Every macOS release from 15.0.0 onward is affected.** `LLVM_ENABLE_ZSTD` first appears in LLVM 15 (LLVM 13 and 14: zero occurrences in `llvm/CMakeLists.txt`), and this workflow has never disabled it. 14.0.0 is clean only because the option didn't exist yet — which is also why Arduino IDE 2, pinned to 14.0.0, has no matching bug report. This is **not** a consequence of the crossbuild removal, despite the timing; 15.0.0 leaks from the crossbuild era.

`-DBUILD_SHARED_LIBS=OFF` is not the protection it looks like: it statically links LLVM's *own* libraries and says nothing about external dependencies.

## The fix

`-DLLVM_ENABLE_ZSTD=OFF`, making the result deterministic regardless of what is installed on the runner.

Nothing we ship uses zstd. In LLVM it backs compressed debug sections and ELF `ELFCOMPRESS_ZSTD` — codegen and linking concerns. clangd parses and indexes and never emits an object file; zstd arrives transitively via `libLLVMSupport`, which clangd links wholesale. clangd's index *does* compress its string table, but through the separate `LLVM_ENABLE_ZLIB` path, which this PR deliberately leaves alone.

**zlib is intentionally not disabled. clangd genuinely uses it.**

## Also in this PR

### Fix `cmake --build` — this branch currently cannot build at all

`69b5e89` ("Simplified workflow") merged the old `cmake` and `build` steps into one, but kept the argument from when they were separate:

```
cd $LLVM_VERSION && cd build          # cwd is now .../llvm-project-22.1.8.src/build
cmake --build $LLVM_VERSION/build     # resolves to .../build/llvm-project-22.1.8.src/build
```

That doubled path does not exist, so `cmake --build` fails with "could not load cache". `git tag --contains 69b5e89` is empty — **no tag points at that commit, so it has never run.** 22.1.8 was cut from `0da9378`, where the build was still its own step at workspace root and the path was correct.

Without this, tagging fails before reaching the zstd change. Now `cmake --build .`.

For reassurance on the rest of that refactor: the matrix runner labels are unchanged from `0da9378`, and the artifact names are byte-identical (`clang_${name}_${arch}` → `clang_${name}` produces the same `clang_macOS_64bit` strings that `create-release`'s `target_folders` expects). The broken build line was the only untested delta.

### Make the `otool` check assert

Lines 76–81 already ran `otool -L` on macOS and **printed** the output. The leak has been sitting in green CI logs the whole time — printing without asserting is precisely how this shipped. Now it fails the job, and covers `clang-format` too, which had never been inspected. `tail -n +2` skips `otool`'s own header line so a build path can't produce a false positive.

### Derive `LLVM_VERSION` from `TAG`

The tag is fed straight into the upstream LLVM download URL, so the tag must name a real LLVM release. Verified: `llvmorg-22.1.8` exists (published 2026-06-16); `llvmorg-22.1.9` and `22.1.10` are 404. So "just tag 22.1.9" does not work today.

This strips a build-revision suffix (`22.1.8-1` → `22.1.8`) in the fetch step, so we can ship a rebuild of the same LLVM version. GitHub Actions expressions have no string-split, hence `GITHUB_ENV` rather than the workflow-level `env:` block; `GITHUB_ENV` applies to subsequent steps, so later steps keep using `${{ env.LLVM_VERSION }}` unchanged. Asset names stay on `TAG`, so they carry the `-1`. The existing tag filter `"[0-9]+.[0-9]+.[0-9]+*"` already permits it.

**Do not fix this by deleting and re-pushing tag `22.1.8`.** Consumers cache by version *string* — App Lab's `check_version` in `scripts/common.sh` compares a stored `clangd.version` file against the pin and skips the download when they match. Overwriting 22.1.8 in place would leave every dev machine and CI cache that already holds "22.1.8" silently keeping the broken binary. A new tag also yields distinct asset filenames, which is what makes downstream caches invalidate correctly.

## Release plan

Tag `22.1.8-1` (same LLVM sources, new build revision).

## Still unverified — worth a look during review

- **Linux.** This branch builds Linux natively on `ubuntu-22.04` / `ubuntu-22.04-arm` with `os-cmake-args: ''`, having dropped the old cross-build's `-static-libstdc++ -static-libgcc`. Two possible regressions, neither confirmed: zstd may now link as `libzstd.so.1` (a soname, so it resolves on distros that have it — far less severe than the macOS case), and the binaries may carry a `GLIBCXX` requirement from the runner toolchain that breaks on older distros. The new check is macOS-only. Worth running on the CI artifacts:
  ```
  readelf -d clangd | grep NEEDED
  objdump -T clangd | grep -o 'GLIBCXX_[0-9.]*' | sort -uV | tail -1
  ```
- **A Homebrew-free Mac is the only real end-to-end test.** Any machine with Homebrew resolves the leaked path fine and shows a false pass.

## Downstream follow-up (not this repo)

App Lab pins clangd **22.1.8 for all platforms**, so macOS users stay broken until this lands. Once released: bump `clangd` in `standalone-apps/app-lab-desktop/internal/lsp/scripts/versions.json`, re-run `download_clangd.sh`, confirm `otool -L <extracted>/clangd | grep -E '/opt/homebrew|/usr/local/opt' || echo CLEAN`, and check that signing/notarization survive with `codesign --verify --deep --strict`.

If this release slips, an interim **macOS-only** pin to 14.0.0 is a viable fallback — it publishes both macOS arches and is the pairing IDE 2 already ships. It must be applied per-platform: 14.0.0 has no Windows ARM64 asset, so a blanket downgrade would trip the missing-asset path in `internal/lsp/artifacts/artifacts.go`.