### PR TITLE
Ship clangd's resource headers in the clangd archive

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,13 +54,13 @@ jobs:
             bindir: '/build/bin'
           - name: Windows_64bit
             runner: windows-latest
-            os-cmake-args: '-Thost=x64 -DCMAKE_CXX_FLAGS="/MP /std:c++14" -DLLVM_USE_CRT_MINSIZEREL="MT"'
+            os-cmake-args: '-Thost=x64 -DCMAKE_CXX_FLAGS="/MP /std:c++14" -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded'
             build-args: '--config MinSizeRel'
             bindir: '/build/MinSizeRel/bin'
             extension: .exe
           - name: Windows_ARM64
             runner: windows-11-arm
-            os-cmake-args: '-DCMAKE_CXX_FLAGS="/MP /std:c++14" -DLLVM_USE_CRT_MINSIZEREL="MT"'
+            os-cmake-args: '-DCMAKE_CXX_FLAGS="/MP /std:c++14" -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded'
             build-args: '--config MinSizeRel'
             bindir: '/build/MinSizeRel/bin'
             extension: .exe
@@ -113,6 +113,33 @@ jobs:
           fi
         done
         echo "resource headers: $(find "$incdir" -type f | wc -l) files in $incdir"
+        exit $status
+
+    - name: Check Windows CRT linkage
+      if: contains(matrix.config.runner, 'windows')
+      # These binaries must not import the VC++ runtime. On a machine without a
+      # 2019-or-later redistributable they exit immediately with 0xC0000135
+      # (STATUS_DLL_NOT_FOUND) printing nothing at all -- not even for --version --
+      # which surfaces downstream as a language server that hangs with no diagnostics.
+      #
+      # This is easy to get silently wrong: the static CRT used to be selected with
+      # LLVM_USE_CRT_<CONFIG>, implemented by llvm/cmake/modules/ChooseMSVCCRT.cmake,
+      # which LLVM deleted in 18 in favour of CMake's own CMAKE_MSVC_RUNTIME_LIBRARY.
+      # The old flag then became an unused cache variable -- no error, just a "manually
+      # specified variables were not used" notice -- and the builds started importing
+      # the runtime. Assert the linkage instead of trusting the flag.
+      run: |
+        status=0
+        for bin in clangd clang-format; do
+          path="${{ env.LLVM_VERSION }}${{ matrix.config.bindir }}/$bin${{ matrix.config.extension }}"
+          for dll in MSVCP140.dll VCRUNTIME140.dll VCRUNTIME140_1.dll; do
+            if grep -a -q "$dll" "$path"; then
+              echo "::error::$bin imports $dll -- the MSVC runtime is linked dynamically"
+              status=1
+            fi
+          done
+        done
+        [[ $status -eq 0 ]] && echo "no MSVC runtime imports: CRT is linked statically"
         exit $status
 
     - name: Check macOS dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,20 @@ env:
   AWS_PLUGIN_TARGET: /tools/
   AWS_REGION: "us-east-1"
   TAG: ${{ github.ref_name }}
+  # Directory holding clangd's builtin headers (stddef.h, float.h, the __stddef_* family,
+  # target intrinsics, ...), shipped inside the clangd archive next to the executable.
+  # From clangd 21 on, BuiltinHeaderPolicy defaults to Clangd, so the --query-driver system
+  # include extractor *drops* the cross toolchain's builtin include dir assuming clangd
+  # supplies its own. Shipping the bare executable leaves those headers nowhere to be
+  # found; macOS/Linux mask it via the host SDK, Windows breaks outright.
+  #
+  # Building with -DCLANG_RESOURCE_DIR=<name> makes clangd look in <dir-of-clangd>/<name>
+  # (clang::GetResourcesPath in clang/lib/Options/OptionUtils.cpp) rather than LLVM's
+  # default <dir-of-clangd>/../lib/clang/<major>, and relocates the clang-resource-headers
+  # build output to <bindir>/<name>/include (cmake/Modules/GetClangResourceDir.cmake). A
+  # sibling directory keeps the archive flat, so consumers that extract only
+  # clang_<platform>/clangd are unaffected and the headers survive --strip-components.
+  CLANG_RESOURCE_DIRNAME: clang-resource
   # LLVM_VERSION is derived from TAG by the "Get llvm-project" step, so that a
   # build-revision tag (e.g. 22.1.8-1) still resolves to the 22.1.8 LLVM sources.
   # NOTE: zstd is deliberately disabled. LLVM_ENABLE_ZSTD defaults to ON, which means
@@ -82,8 +96,24 @@ jobs:
         cd ${{ env.LLVM_VERSION }}
         mkdir build
         cd build
-        cmake ../llvm ${{ env.COMMON_CMAKE_ARGS }} ${{ matrix.config.os-cmake-args }}
-        cmake --build . ${{ matrix.config.build-args }} --target clang-format clangd
+        cmake ../llvm ${{ env.COMMON_CMAKE_ARGS }} -DCLANG_RESOURCE_DIR=${{ env.CLANG_RESOURCE_DIRNAME }} ${{ matrix.config.os-cmake-args }}
+        cmake --build . ${{ matrix.config.build-args }} --target clang-format clangd clang-resource-headers
+
+    - name: Check clangd resource headers
+      # Guard against silently shipping a clangd with no builtin headers again: that
+      # failure is invisible on macOS/Linux (the host SDK masks it) and only bites on
+      # Windows, so assert the headers exist on every platform instead.
+      run: |
+        incdir="${{ env.LLVM_VERSION }}${{ matrix.config.bindir }}/${{ env.CLANG_RESOURCE_DIRNAME }}/include"
+        status=0
+        for header in stddef.h stdint.h stdarg.h float.h limits.h stdbool.h __stddef_max_align_t.h; do
+          if [[ ! -f "$incdir/$header" ]]; then
+            echo "::error::missing builtin header $header in $incdir"
+            status=1
+          fi
+        done
+        echo "resource headers: $(find "$incdir" -type f | wc -l) files in $incdir"
+        exit $status
 
     - name: Check macOS dependencies
       if: contains(matrix.config.runner, 'macos')
@@ -103,9 +133,13 @@ jobs:
       uses: actions/upload-artifact@v7
       with:
         name: clang_${{ matrix.config.name }}
+        # All three paths live under bindir, so the artifact root (upload-artifact's least
+        # common ancestor of the search paths) stays bindir and the two executables stay at
+        # the artifact root exactly as before.
         path: |
           ${{ env.LLVM_VERSION }}${{ matrix.config.bindir }}/clangd${{ matrix.config.extension }}
           ${{ env.LLVM_VERSION }}${{ matrix.config.bindir }}/clang-format${{ matrix.config.extension }}
+          ${{ env.LLVM_VERSION }}${{ matrix.config.bindir }}/${{ env.CLANG_RESOURCE_DIRNAME }}/**
 
   create-release:
     runs-on: ubuntu-latest
@@ -125,10 +159,14 @@ jobs:
           declare -a target_folders=("Linux_64bit" "Linux_ARM64" "macOS_64bit" "macOS_ARM64" "Windows_64bit" "Windows_ARM64")
           for folder in "${target_folders[@]}"
           do
-            chmod -v +x clang_$folder/*
+            # Only the executables get the exec bit. The resource headers are data files,
+            # so don't blanket-chmod the folder now that it holds more than two binaries.
+            chmod -v +x clang_$folder/clangd* clang_$folder/clang-format*
             CLANGD=clangd_${{ env.TAG }}_${folder}.tar.bz2
             CLANGFORMAT=clang-format_${{ env.TAG }}_${folder}.tar.bz2
-            tar -cvjf $CLANGD clang_$folder/clangd*
+            # clangd needs its resource headers alongside the binary; clang-format has no
+            # use for them, so that archive keeps exactly the contents it always had.
+            tar -cvjf $CLANGD clang_$folder/clangd* clang_$folder/${{ env.CLANG_RESOURCE_DIRNAME }}
             tar -cvjf $CLANGFORMAT clang_$folder/clang-format*
           done
           mv -v clang*.tar.bz2 ${{ env.DIST_DIR }}/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,6 +176,10 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           draft: false
+          # Tags carrying an -rc suffix (e.g. 22.1.8-rc1) publish as a prerelease, so the
+          # assets are downloadable by exact tag for testing without the release becoming
+          # "Latest" or being picked up by anything tracking releases/latest.
+          prerelease: ${{ contains(env.TAG, '-rc') }}
           # NOTE: "Artifact is a directory" warnings are expected and don't indicate a problem
           # (all the files we need are in the release folder root)
           artifacts: ${{ env.DIST_DIR }}/*

--- a/README.md
+++ b/README.md
@@ -8,3 +8,26 @@ Versions for Linux ARM are also available, cross-compiled from the Linux host.
 
 The latest available builds are [here](https://github.com/arduino/clang-static-binaries/releases/latest).
 Go to the [releases page](https://github.com/arduino/clang-static-binaries/releases) for all the available versions.
+
+## Archive contents
+
+`clang-format_<version>_<platform>.tar.bz2` contains a single executable:
+
+```
+clang_<platform>/clang-format[.exe]
+```
+
+`clangd_<version>_<platform>.tar.bz2` additionally ships clangd's resource directory, which
+holds its builtin headers (`stddef.h`, `stdint.h`, `float.h`, the `__stddef_*` family, the
+target intrinsics headers, ...):
+
+```
+clang_<platform>/clangd[.exe]
+clang_<platform>/clang-resource/include/...
+```
+
+**Extract the whole `clang_<platform>/` tree.** clangd looks for its resource directory next
+to its own executable, so `clang-resource` must stay a sibling of the binary. Without it,
+clangd 21 and later report builtin headers as missing whenever a `--query-driver`
+cross-compilation toolchain is in use — silently masked by the host SDK on macOS and Linux,
+but broken outright on Windows.


### PR DESCRIPTION
[Author - Claude Opus 5]

The clangd archives contained only the executable, so clangd had no clang resource directory and none of its builtin headers (`stddef.h`, `stdint.h`, `stdarg.h`, `float.h`, `limits.h`, the `__stddef_*` family, the target intrinsics headers).

From clangd 21 on this stopped being survivable. BuiltinHeaderPolicy now defaults to Clangd, so SystemIncludeExtractor runs `$DRIVER -print-file-name=include` and *removes* the toolchain's builtin include directory from the `--query-driver` results, assuming clangd will supply those headers itself. With no resource dir they were removed and nothing replaced them.

macOS and Linux masked the loss by falling back on host system headers via `-isysroot`. Windows has no `/usr/include` and no SDK fallback, so the builtins vanished outright: every libstdc++ header opens with `bits/c++config.h`, which needs them, so the include graph under `Arduino.h` collapsed and core symbols (`Serial`, `pinMode`, ...) reported as undeclared.

Build with `-DCLANG_RESOURCE_DIR=clang-resource` and add the clang-resource-headers target. That cache variable does double duty: clangd resolves its resource dir as `<dir-of-clangd>/clang-resource` (`clang::GetResourcesPath`, `clang/lib/Options/OptionUtils.cpp`) instead of the default `<dir-of-clangd>/../lib/clang/<major>`, and it relocates the header build output to `<bindir>/clang-resource/include`
(`cmake/Modules/GetClangResourceDir.cmake`) — next to the binaries, so the upload and packaging steps pick it up without any staging.

The resource dir ships as a sibling of the executable rather than in LLVM's canonical `bin/` + `../lib/clang/<major>` layout, which keeps this additive: clangd stays at `clang_<platform>/clangd`, so consumers that extract just that one path are byte-for-byte unaffected. Consumers opt in by extracting the whole `clang_<platform>/` tree, and because the resource dir is a sibling it survives any `--strip-components` they already apply.

clang-format has no use for the headers, so its archive is untouched.

Verified against a local LLVM 22.1.8 build (macOS ARM64) driving clangd the way arduino-language-server does, over a real `arduino:zephyr:unoq` compilation database with the arm-zephyr-eabi GCC 12.2.0 toolchain:

  - before: builtin headers ... excluded -> 'float.h' file not found
  - after:  builtin headers ... excluded (policy working as designed), and no builtin header goes missing

Removing the shipped clang-resource from that same build reproduces the 'float.h' failure exactly, and planting the headers at the default `../lib/clang/22` instead behaves identically to the sibling layout, which isolates the fix to the presence of the headers rather than their location.